### PR TITLE
fix text code snippet overflow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,3 +117,7 @@ button:hover {
 .blog-content a {
   @apply text-blue-500 break-words;
 }
+
+pre {
+  @apply whitespace-pre-line break-words;
+}


### PR DESCRIPTION
* Problem: current code snippet texts are getting out of the snippet box area for smaller screens.
* Fix: 
``` white-space: pre-line and word-break: normal ``` 
for all pre elements to break to the next line.
![alt image](https://i.ibb.co/nMpFdkp/snippet-text-overflow.png)